### PR TITLE
 support for non SQL databases added

### DIFF
--- a/Ralms.EntityFrameworkCore.Extensions/WithHint/RalmsQueryableExtensions.cs
+++ b/Ralms.EntityFrameworkCore.Extensions/WithHint/RalmsQueryableExtensions.cs
@@ -14,9 +14,12 @@
  *
  */
 
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore
@@ -34,6 +37,15 @@ namespace Microsoft.EntityFrameworkCore
             [NotParameterized] string hint)
             where TEntity : class
         {
+            var infrastructure = source as IInfrastructure<IServiceProvider>;
+            var serviceProvider = infrastructure.Instance;
+            var currentDbContext = serviceProvider.GetService(typeof(ICurrentDbContext))
+                                       as ICurrentDbContext;
+            var providerName = currentDbContext.Context.Database.ProviderName;
+
+            if (providerName != "Microsoft.EntityFrameworkCore.SqlServer")
+                return source;
+
             return source.Provider.CreateQuery<TEntity>(
                 Expression.Call(
                     null,
@@ -44,3 +56,4 @@ namespace Microsoft.EntityFrameworkCore
         #endregion 
     }
 }
+


### PR DESCRIPTION
By ignoring hint queries in non-SQL providers, we don't need to add these extensions just to SQL-Server providers. So simply we can mock data layer by using in-memory database and test the same code there.